### PR TITLE
Add DTX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 
 CFLAGS += -MMD -Wall
+LDFLAGS="-Wl,--copy-dt-needed-entries"
 
 LDLIBS_ASOUND ?= -lasound
 LDLIBS_OPUS ?= -lopus

--- a/rx.c
+++ b/rx.c
@@ -195,6 +195,7 @@ int main(int argc, char *argv[])
 		port = DEFAULT_PORT;
 
 	fputs(COPYRIGHT "\n", stderr);
+	fputs("2E0SIP's DTX fork\n", stderr);
 
 	for (;;) {
 		int c;
@@ -245,6 +246,7 @@ int main(int argc, char *argv[])
 
 	ortp_init();
 	ortp_scheduler_init();
+	ortp_set_log_level_mask(NULL, ORTP_ERROR);
 	session = create_rtp_recv(addr, port, jitter);
 	assert(session != NULL);
 

--- a/tx.c
+++ b/tx.c
@@ -184,6 +184,7 @@ int main(int argc, char *argv[])
 		port = DEFAULT_PORT;
 
 	fputs(COPYRIGHT "\n", stderr);
+	fputs("2E0SIP's dodgy DTX fork\n", stderr);
 
 	for (;;) {
 		int c;
@@ -236,6 +237,14 @@ int main(int argc, char *argv[])
 			opus_strerror(error));
 		return -1;
 	}
+
+	ret = opus_encoder_ctl(enc, OPUS_SET_DTX(1));
+ 	if (ret != OPUS_OK) {
+		fprintf(stderr, "opus_encoder_ctl: Error enabling DTX");		
+		return -1
+	}
+
+
 
 	bytes_per_frame = kbps * 1024 * frame / rate / 8;
 

--- a/tx.c
+++ b/tx.c
@@ -97,11 +97,10 @@ static int send_one_frame(snd_pcm_t *snd,
 	if (z < 0) {
 		fprintf(stderr, "opus_encode_float: %s\n", opus_strerror(z));
 		return -1;
-	} else if ( z == 1) { /* If the packet length is one DTX is active, so we don't send the packet*/
-		return 0;
+	} else if ( z > 1) { /* If the packet length is greater than one DTX is not active, so we send the packet*/
+		rtp_session_send_with_ts(session, packet, z, ts);
 	}
 
-	rtp_session_send_with_ts(session, packet, z, ts);
 	ts += ts_per_frame;
 
 	return 0;
@@ -186,7 +185,7 @@ int main(int argc, char *argv[])
 		port = DEFAULT_PORT;
 
 	fputs(COPYRIGHT "\n", stderr);
-	fputs("2E0SIP's dodgy DTX fork\n", stderr);
+	fputs("2E0SIP's DTX fork\n", stderr);
 
 	for (;;) {
 		int c;
@@ -251,6 +250,7 @@ int main(int argc, char *argv[])
 	bytes_per_frame = kbps * 1024 * frame / rate / 8;
 
 	/* Follow the RFC, payload 0 has 8kHz reference rate */
+	/* 960 * 8000 / 48000 = 160 */
 
 	ts_per_frame = frame * 8000 / rate;
 

--- a/tx.c
+++ b/tx.c
@@ -97,6 +97,8 @@ static int send_one_frame(snd_pcm_t *snd,
 	if (z < 0) {
 		fprintf(stderr, "opus_encode_float: %s\n", opus_strerror(z));
 		return -1;
+	} else if ( z == 1) { /* If the packet length is one DTX is active, so we don't send the packet*/
+		return 0;
 	}
 
 	rtp_session_send_with_ts(session, packet, z, ts);

--- a/tx.c
+++ b/tx.c
@@ -238,10 +238,10 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 
-	ret = opus_encoder_ctl(enc, OPUS_SET_DTX(1));
+	ret = opus_encoder_ctl(encoder, OPUS_SET_DTX(1));
  	if (ret != OPUS_OK) {
 		fprintf(stderr, "opus_encoder_ctl: Error enabling DTX");		
-		return -1
+		return -1;
 	}
 
 

--- a/tx.c
+++ b/tx.c
@@ -165,7 +165,7 @@ static void usage(FILE *fd)
 
 int main(int argc, char *argv[])
 {
-	int r, error;
+	int r, error, ret;
 	size_t bytes_per_frame;
 	unsigned int ts_per_frame;
 	snd_pcm_t *snd;


### PR DESCRIPTION
This is a crude patch to enable Discontinuous Transmission (DTX) support. When DTX is enabled, during periods of silence a packet is only sent every 400ms. This reduces overhead and bandwidth.

Unfortunately this is currently resulting in the underlying ORTP library on the receiver side to spit warnings as it's expecting a packet every at least every 256ms (Jitter buffer x 16). I've changed the log level as a work around, and asked on the mailing list if there's a more robust solution. 

Once a solution has been found and there's a flag to enable / disable DTX, I'll attempt to get the changes merged back into the original project.